### PR TITLE
Use same port as in main.go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM scratch
 
 COPY bin/mosquitto_exporter /mosquitto_exporter
 
-EXPOSE 9324
+EXPOSE 9234
 
 ENTRYPOINT [ "/mosquitto_exporter" ]


### PR DESCRIPTION
In `main.go` you use port `9234` which is not exposed within your Dockerfile.