### PR TITLE
Replacing dash in metrics name

### DIFF
--- a/main.go
+++ b/main.go
@@ -237,6 +237,7 @@ func parseTopic(topic string) string {
 	name := strings.Replace(topic, "$SYS/", "", 1)
 	name = strings.Replace(name, "/", "_", -1)
 	name = strings.Replace(name, " ", "_", -1)
+	name = strings.Replace(name, "-", "_", -1)
 	return name
 }
 


### PR DESCRIPTION
Mosquitto allows the use of the '-' character in topic names. We have a topic name with a '-' and the mosquitto exporter fails when creating the Prometheus metric because it does allow the '-' character.