### PR TITLE
Fix topic parsing

### DIFF
--- a/main.go
+++ b/main.go
@@ -238,6 +238,7 @@ func parseTopic(topic string) string {
 	name = strings.Replace(name, "/", "_", -1)
 	name = strings.Replace(name, " ", "_", -1)
 	name = strings.Replace(name, "-", "_", -1)
+	name = strings.Replace(name, ".", "_", -1)
 	return name
 }
 


### PR DESCRIPTION
Bridge metric looks like '$SYS/broker/connection/BROKER.BRIDGE/state',
while '.' is not a valid character for prometheus metrics name.
This commit replace '.' by '_'