### PR TITLE
Add metrics for monitoring the broker and connection status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-PKG_NAME:=github.com/sapcc/mosquitto-exporter
+#PKG_NAME:=github.com/sapcc/mosquitto-exporter
+PKG_NAME:=github.com/daviddetorres/mosquitto-exporter
 BUILD_DIR:=bin
 MOSQUITTO_EXPORTER_BINARY:=$(BUILD_DIR)/mosquitto_exporter
 IMAGE := sapcc/mosquitto-exporter
@@ -10,13 +11,18 @@ GOARCH=amd64
 help:
 	@echo
 	@echo "Available targets:"
-	@echo "  * build             - build the binary, output to $(ARC_BINARY)"
-	@echo "  * linux             - build the binary, output to $(ARC_BINARY)"
+	@echo "  * build             - build the binary, output to $(BUILD_DIR)"
+	@echo "  * linux             - build the binary, output to $(BUILD_DIR)"
 	@echo "  * docker            - build docker image"
 
 .PHONY: build
 build:
 	@mkdir -p $(BUILD_DIR)
+	# Install dependencies
+	go get github.com/codegangsta/cli
+	go get github.com/eclipse/paho.mqtt.golang
+	go get github.com/prometheus/client_golang/prometheus
+	# Build sources
 	go build -o $(MOSQUITTO_EXPORTER_BINARY) -ldflags="$(LDFLAGS)" $(PKG_NAME)
 
 linux: export GOOS=linux

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,6 @@ help:
 .PHONY: build
 build:
 	@mkdir -p $(BUILD_DIR)
-	# Install dependencies
-	go get github.com/codegangsta/cli
-	go get github.com/eclipse/paho.mqtt.golang
-	go get github.com/prometheus/client_golang/prometheus
-	go get github.com/sapcc/mosquitto-exporter
 	# Build sources
 	go build -o $(MOSQUITTO_EXPORTER_BINARY) -ldflags="$(LDFLAGS)" $(PKG_NAME)
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-#PKG_NAME:=github.com/sapcc/mosquitto-exporter
-PKG_NAME:=github.com/daviddetorres/mosquitto-exporter
+PKG_NAME:=github.com/sapcc/mosquitto-exporter
 BUILD_DIR:=bin
 MOSQUITTO_EXPORTER_BINARY:=$(BUILD_DIR)/mosquitto_exporter
 IMAGE := sapcc/mosquitto-exporter
@@ -22,6 +21,7 @@ build:
 	go get github.com/codegangsta/cli
 	go get github.com/eclipse/paho.mqtt.golang
 	go get github.com/prometheus/client_golang/prometheus
+	go get github.com/sapcc/mosquitto-exporter
 	# Build sources
 	go build -o $(MOSQUITTO_EXPORTER_BINARY) -ldflags="$(LDFLAGS)" $(PKG_NAME)
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -41,8 +42,9 @@ var (
 		"$SYS/broker/clients/maximum":           "The maximum number of clients connected simultaneously since the broker started",
 		"$SYS/broker/clients/total":             "The total number of clients connected since the broker started.",
 	}
-	counterMetrics = map[string]*MosquittoCounter{}
-	gaugeMetrics   = map[string]prometheus.Gauge{}
+	counterMetrics       = map[string]*MosquittoCounter{}
+	gaugeMetrics         = map[string]prometheus.Gauge{}
+	firstMessageReceived = false
 )
 
 func main() {
@@ -110,15 +112,24 @@ func runServer(c *cli.Context) {
 	opts := mqtt.NewClientOptions()
 	opts.SetCleanSession(true)
 	opts.AddBroker(c.String("endpoint"))
-	
-	// initializes the "broker up" metric to 0 (down)
+	opts.SetClientID(fmt.Sprintf("prometheus_mosquitto_exporter_%v", time.Now().Unix()))
+
+	// initializes the "broker_connection_up" metric to 0 (down)
 	gaugeMetrics["broker_connection_up"] = prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "broker_connection_up",
-			Help: "broker up/down",
-		})
+		Name: "broker_connection_up",
+		Help: "broker up/down",
+	})
 	prometheus.MustRegister(gaugeMetrics["broker_connection_up"])
 	gaugeMetrics["broker_connection_up"].Set(0)
-	
+
+	// initializes the "seconds_from_last_update" metric to -1
+	gaugeMetrics["broker_seconds_from_last_update"] = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "broker_seconds_from_last_update",
+		Help: "secondes from las update of metrics, if not received ever: -1",
+	})
+	prometheus.MustRegister(gaugeMetrics["broker_seconds_from_last_update"])
+	gaugeMetrics["broker_seconds_from_last_update"].Set(-1)
+
 	// if you have a username you'll need a password with it
 	if c.String("user") != "" {
 		opts.SetUsername(c.String("user"))
@@ -149,7 +160,7 @@ func runServer(c *cli.Context) {
 
 	opts.OnConnect = func(client mqtt.Client) {
 		log.Printf("Connected to %s", c.String("endpoint"))
-		// update the "broker up" metric (up)
+		// update the "broker_connection_up" metric (up)
 		gaugeMetrics["broker_connection_up"].Set(1)
 		// subscribe on every (re)connect
 		token := client.Subscribe("$SYS/#", 0, func(_ mqtt.Client, msg mqtt.Message) {
@@ -164,15 +175,20 @@ func runServer(c *cli.Context) {
 	}
 	opts.OnConnectionLost = func(client mqtt.Client, err error) {
 		log.Printf("Error: Connection to %s lost: %s", c.String("endpoint"), err)
-		// update the "broker up" metric (down)
+		// update the "broker_connection_up" metric (down)
 		gaugeMetrics["broker_connection_up"].Set(0)
 		// try to reconnect
-		mqttConnect(client, c)
+		//mqttConnect(client, c)
 	}
 	client := mqtt.NewClient(opts)
 
+	// launch the first connection in another thread so it is no blocking
+	// and exporter can serve metrics in case of no connection
 	go mqttConnect(client, c)
-	
+
+	// start counter of seconds from last update
+	go increaseSecondsSinceLastUpdate()
+
 	// init the router and server
 	http.Handle("/metrics", prometheus.Handler())
 	http.HandleFunc("/", serveVersion)
@@ -182,7 +198,7 @@ func runServer(c *cli.Context) {
 }
 
 // try to connect forever with the MQTT broker
-func mqttConnect(client mqtt.Client, c *cli.Context){
+func mqttConnect(client mqtt.Client, c *cli.Context) {
 	// try to connect forever
 	for {
 		token := client.Connect()
@@ -190,9 +206,9 @@ func mqttConnect(client mqtt.Client, c *cli.Context){
 			if token.Error() == nil {
 				break
 			}
-			log.Printf("Error: Failed to connect to broker: %s", token.Error())
+			log.Printf("Error: Failed to connect to broker: %v", token.Error())
 		} else {
-			log.Printf("Timeout connecting to endpoint %s", c.GlobalString("endpoint"))
+			log.Printf("Timeout connecting to endpoint")
 		}
 		time.Sleep(5 * time.Second)
 	}
@@ -209,15 +225,26 @@ func processUpdate(topic, payload string) {
 			//log.Printf("Processing gauge metric %s with data %s", topic, payload)
 			processGaugeMetric(topic, payload)
 		}
+		restartSecondsSinceLastUpdate()
 	}
 }
 
-func restartSecondsSinceLastUpdate(){
-	
+func restartSecondsSinceLastUpdate() {
+	// if it is the first message received set the firstMessageReceived flag true
+	if firstMessageReceived == false {
+		firstMessageReceived = true
+	}
+	// restart the timer from last message received to 0
+	gaugeMetrics["broker_seconds_from_last_update"].Set(0)
 }
 
-func increaseSecondsSinceLastUpdate(){
-	
+func increaseSecondsSinceLastUpdate() {
+	for {
+		if firstMessageReceived == true {
+			gaugeMetrics["broker_seconds_from_last_update"].Inc()
+		}
+		time.Sleep(time.Second)
+	}
 }
 
 func processCounterMetric(topic, payload string) {

--- a/main.go
+++ b/main.go
@@ -166,11 +166,11 @@ func runServer(c *cli.Context) {
 		// update the "broker up" metric (down)
 		gaugeMetrics["broker_connection_up"].Set(0)
 		// try to reconnect
-		mqttConnect()
+		mqttConnect(client)
 	}
 	client := mqtt.NewClient(opts)
 
-	mqttConnect()
+	mqttConnect(client)
 	
 	// init the router and server
 	http.Handle("/metrics", prometheus.Handler())
@@ -181,7 +181,7 @@ func runServer(c *cli.Context) {
 }
 
 // try to connect forever with the MQTT broker
-func mqttConnect(){
+func mqttConnect(client mqtt.Client){
 	// try to connect forever
 	for {
 		token := client.Connect()


### PR DESCRIPTION
As proposed in issue #12 , it is needed a way to check the availability and health of the broker in order to be able to raise alarms in case of broker down or malfunction. 

This is due to the metrics shown are the last one received, but as they are served as a push service the exporter acts as a proxy and in case of disconnection the exporter will continue showing results. 

Two scenarios are contemplated: 
- Lost of connection with the broker: new metric "broker_connection_up" (0 if down, 1 if up)
- Connection is ok, but the broker does not send updates due to problems in the queue, blockage, etc. Added new metric "seconds_since_last_update". (-1 if never received an update and > 0 since first update, restarting to 0 after every update from the broker). 
