### PR TITLE
Reset all counters to zero on disconnect from broker

### DIFF
--- a/main.go
+++ b/main.go
@@ -168,7 +168,8 @@ func runServer(c *cli.Context) {
 		}
 	}
 	opts.OnConnectionLost = func(client mqtt.Client, err error) {
-		log.Printf("Error: Connection to %s lost: %s", c.String("endpoint"), err)
+		log.Printf("Error: Connection to %s lost: %s, resetting counters", c.String("endpoint"), err)
+		resetMetrics()
 	}
 	client := mqtt.NewClient(opts)
 
@@ -192,6 +193,19 @@ func runServer(c *cli.Context) {
 	log.Printf("Listening on %s...", c.GlobalString("bind-address"))
 	err := http.ListenAndServe(c.GlobalString("bind-address"), nil)
 	fatalfOnError(err, "Failed to bind on %s: ", c.GlobalString("bind-address"))
+}
+
+func resetMetrics() {
+	for topic, _ := range counterMetrics {
+		if counterMetrics[topic] != nil {
+			counterMetrics[topic].Set(0)
+		}
+	}
+	for topic, _ := range gaugeMetrics {
+		if gaugeMetrics[topic] != nil {
+			gaugeMetrics[topic].Set(0)
+		}
+	}
 }
 
 // $SYS/broker/bytes/received


### PR DESCRIPTION
I used the exporter to monitor a Mosquitto instance. But realised the counters continue to publish last known value, if the broker stopped working. As a first fix I simply reset the counters to zero on broker disconnect.
